### PR TITLE
Support importing cards from specific sets

### DIFF
--- a/src/boardState.js
+++ b/src/boardState.js
@@ -1,21 +1,19 @@
 // Manages state of a "board". Purely a logical representation, doesn't know about React components.
 export default class BoardState {
-  constructor(cardLoader, cardNames, numCols, parentComponent = null) {
+  // cardEntries - Array of objects with keys: {name, quantity, set}
+  constructor(cardLoader, cardEntries, numCols, parentComponent = null) {
     this.cardLoader = cardLoader;
-    if (!cardNames) {
-      cardNames = [];
-    }
     this.numCols = numCols;
-    this.loadCardPool(cardNames, parentComponent);
+    this.loadCardPool(cardEntries, parentComponent);
   }
 
-  async loadCardPool(cardNames, parentComponent) {
+  async loadCardPool(cardEntries, parentComponent) {
     this.cardColumns = [...Array(this.numCols)].map(_ => []); // Initialize with numCols empty arrays
-    for (var name of cardNames) {
+    for (var entry of cardEntries) {
       // TODO: A major refactor is needed to simplify state management. Not sure how best to it,
       // but one option could be to merge this class with the Board react component. Until then,
       // we need this manual refresh.
-      this.createAndAddCards(name).then(value => {
+      this.createAndAddCards(entry).then(value => {
         if (parentComponent) {
           parentComponent.setState({});
         }
@@ -25,10 +23,10 @@ export default class BoardState {
 
   // Creates a new card object, including initializing it with Scryfall data and a unique ID,
   // and adds it to this board.
-  async createAndAddCards(cardInfo) {
+  async createAndAddCards(cardEntry) {
     var result;
-    for (var n = 0; n < cardInfo.quantity; n++) {
-      const newCard = await this.cardLoader.getCardData(cardInfo.name, cardInfo.set);
+    for (var n = 0; n < cardEntry.quantity; n++) {
+      const newCard = await this.cardLoader.getCardData(cardEntry.name, cardEntry.set);
       newCard.currentBoard = this;
       this.cardColumns[0].push(newCard);
       result = newCard;

--- a/src/boardState.js
+++ b/src/boardState.js
@@ -1,27 +1,36 @@
 // Manages state of a "board". Purely a logical representation, doesn't know about React components.
 export default class BoardState {
-  constructor(cardLoader, cardNames, numCols) {
+  constructor(cardLoader, cardNames, numCols, parentComponent = null) {
     this.cardLoader = cardLoader;
     if (!cardNames) {
       cardNames = [];
     }
     this.numCols = numCols;
-    this.loadCardPool(cardNames);
+    this.loadCardPool(cardNames, parentComponent);
   }
 
-  async loadCardPool(cardNames) {
+  async loadCardPool(cardNames, parentComponent) {
     this.cardColumns = [...Array(this.numCols)].map(_ => []); // Initialize with numCols empty arrays
-    cardNames.forEach(c => this.createAndAddCards(c));
+    for (var name of cardNames) {
+      this.createAndAddCards(name).then(value => {
+        if (parentComponent) {
+          parentComponent.setState({});
+        }
+      })
+    }
   }
 
   // Creates a new card object, including initializing it with Scryfall data and a unique ID,
   // and adds it to this board.
   async createAndAddCards(cardInfo) {
+    var result;
     for (var n = 0; n < cardInfo.quantity; n++) {
-      const newCard = this.cardLoader.getCardData(cardInfo.name, cardInfo.set);
+      const newCard = await this.cardLoader.getCardData(cardInfo.name, cardInfo.set);
       newCard.currentBoard = this;
       this.cardColumns[0].push(newCard);
+      result = newCard;
     }
+    return result;
   }
 
   // Adds the given card object to this board. Does not create a new card object.

--- a/src/boardState.js
+++ b/src/boardState.js
@@ -11,17 +11,17 @@ export default class BoardState {
 
   async loadCardPool(cardNames) {
     this.cardColumns = [...Array(this.numCols)].map(_ => []); // Initialize with numCols empty arrays
-    cardNames.forEach(c => this.createAndAddCard(c));
+    cardNames.forEach(c => this.createAndAddCards(c));
   }
 
   // Creates a new card object, including initializing it with Scryfall data and a unique ID,
   // and adds it to this board.
-  async createAndAddCard(cardName) {
-    const newCard = this.cardLoader.getCardData(cardName);
-    newCard.currentBoard = this;
-    this.cardColumns[0].push(newCard);
-
-    return newCard;
+  async createAndAddCards(cardInfo) {
+    for (var n = 0; n < cardInfo.quantity; n++) {
+      const newCard = this.cardLoader.getCardData(cardInfo.name, cardInfo.set);
+      newCard.currentBoard = this;
+      this.cardColumns[0].push(newCard);
+    }
   }
 
   // Adds the given card object to this board. Does not create a new card object.

--- a/src/boardState.js
+++ b/src/boardState.js
@@ -12,6 +12,9 @@ export default class BoardState {
   async loadCardPool(cardNames, parentComponent) {
     this.cardColumns = [...Array(this.numCols)].map(_ => []); // Initialize with numCols empty arrays
     for (var name of cardNames) {
+      // TODO: A major refactor is needed to simplify state management. Not sure how best to it,
+      // but one option could be to merge this class with the Board react component. Until then,
+      // we need this manual refresh.
       this.createAndAddCards(name).then(value => {
         if (parentComponent) {
           parentComponent.setState({});

--- a/src/cardLoader.js
+++ b/src/cardLoader.js
@@ -2,6 +2,7 @@
 export default class CardLoader {
   constructor() {
     this.nextId = 0;
+    this.cardDataCache = {};
   }
 
   async getCardData(cardName, set = '') {
@@ -10,11 +11,20 @@ export default class CardLoader {
       id: this.nextId,
     };
     this.nextId++;   
-    await this.getCardDataAsync(cardName, set).then(data => newCard.data = data);
+
+    if (!this.cardDataCache[cardName]) {
+      this.cardDataCache[cardName] = {};
+    }
+
+    if (!this.cardDataCache[cardName][set]) {
+      this.cardDataCache[cardName][set] = await this.getScryfallCardData(cardName, set);
+    }
+
+    newCard.data = this.cardDataCache[cardName][set];
     return newCard;
   }
 
-  async getCardDataAsync(cardName, set = '') {
+  async getScryfallCardData(cardName, set = '') {
     const url = `https://api.scryfall.com/cards/named?exact=${encodeURI(cardName)}&set=${set}`;
     const response = await fetch(url);
     var cardJson = await response.json();

--- a/src/cardLoader.js
+++ b/src/cardLoader.js
@@ -3,19 +3,19 @@ export default class CardLoader {
   constructor() {
     this.nextId = 0;
   }
-  
-  getCardData(cardName) {
+
+  getCardData(cardName, set = '') {
     const newCard = {
       name: cardName,
       id: this.nextId,
     };
     this.nextId++;   
-    this.getCardDataAsync(cardName).then(data => newCard.data = data);
+    this.getCardDataAsync(cardName, set).then(data => newCard.data = data);
     return newCard;
   }
-  
-  async getCardDataAsync(cardName) {
-    const url = `https://api.scryfall.com/cards/named?exact=${encodeURI(cardName)}`;
+
+  async getCardDataAsync(cardName, set = '') {
+    const url = `https://api.scryfall.com/cards/named?exact=${encodeURI(cardName)}&set=${set}`;
     const response = await fetch(url);
     var cardJson = await response.json();
 

--- a/src/cardLoader.js
+++ b/src/cardLoader.js
@@ -46,7 +46,12 @@ export default class CardLoader {
       }
     } catch (e) {
       console.error(`Error parsing card data: ${e}. Card JSON: ${JSON.stringify(cardJson)}`);
-      throw e;
+      return {
+        color_pile : 'C'
+        colors: 'C',
+        cmc: 0,
+        imageURL: `https://api.scryfall.com/cards/named?format=image&exact=${cardName}`
+      }
     }
   }
 }

--- a/src/cardLoader.js
+++ b/src/cardLoader.js
@@ -4,13 +4,13 @@ export default class CardLoader {
     this.nextId = 0;
   }
 
-  getCardData(cardName, set = '') {
+  async getCardData(cardName, set = '') {
     const newCard = {
       name: cardName,
       id: this.nextId,
     };
     this.nextId++;   
-    this.getCardDataAsync(cardName, set).then(data => newCard.data = data);
+    await this.getCardDataAsync(cardName, set).then(data => newCard.data = data);
     return newCard;
   }
 
@@ -42,6 +42,7 @@ export default class CardLoader {
         color_pile,
         colors,
         cmc: cardJson['cmc'],
+        imageURL: cardJson['image_uris']['normal']
       }
     } catch (e) {
       console.error(`Error parsing card data: ${e}. Card JSON: ${JSON.stringify(cardJson)}`);

--- a/src/cardLoader.js
+++ b/src/cardLoader.js
@@ -47,7 +47,7 @@ export default class CardLoader {
     } catch (e) {
       console.error(`Error parsing card data: ${e}. Card JSON: ${JSON.stringify(cardJson)}`);
       return {
-        color_pile : 'C'
+        color_pile : 'C',
         colors: 'C',
         cmc: 0,
         imageURL: `https://api.scryfall.com/cards/named?format=image&exact=${cardName}`

--- a/src/importExport.js
+++ b/src/importExport.js
@@ -15,6 +15,32 @@ const isNumber = (text) => {
 }
 
 class LoadInputButton extends React.Component {
+  parseLine(line) {
+    var [part1, part2] = line.split('(');
+
+    var quantity, name;
+    // If the line starts with a number, consume that part of the string and store in quantity
+    if (isNumber(part1[0])) {
+      const i = part1.indexOf(' ');
+      var quantityPart = part1.substring(0, i)
+      if (quantityPart.endsWith('x')) {
+        quantityPart = quantityPart.slice(0, -1); // trim off "x" in the case of "1x <cardname>"
+      }
+      quantity = Number(quantityPart);
+      name = part1.substring(i).trim();
+    } else {
+      quantity = 1;
+      name = part1.trim();
+    }
+
+    var set = ''
+    if (part2) {
+      set = part2.split(')')[0].trim();
+    }
+
+    return {name, quantity, set};
+  }
+
   inputToCardNames(rawInput) {
     const lines = rawInput.split("\n").filter(l => l.trim().length > 0);
     const [maindeckCardNames, sideboardCardNames] = [[], []];
@@ -26,25 +52,7 @@ class LoadInputButton extends React.Component {
         continue;
       }
 
-      // MTG Arena text format has the set name in () after the card name. Remove that portion if present.
-      line = line.split('(')[0].trim();
-
-      var quantity = 1;
-      // If the line starts with a number, consume that part of the string and store in quantity
-      if (isNumber(line[0])) {
-        const i = line.indexOf(' ');
-        var quantityPart = line.substring(0, i)
-        if (quantityPart.endsWith('x')) {
-          quantityPart = quantityPart.slice(0, -1); // trim off "x" in the case of "1x <cardname>"
-        }
-        quantity = Number(quantityPart);
-        line = line.substring(i).trim();
-      }
-
-      // The remaining portion of the string should be just the card name; add it n times
-      for (var n = 0; n < quantity; n++) {
-        currentSection.push(line);
-      }
+      currentSection.push(this.parseLine(line));
     }
 
     return [maindeckCardNames, sideboardCardNames];

--- a/src/importExport.js
+++ b/src/importExport.js
@@ -41,32 +41,32 @@ class LoadInputButton extends React.Component {
     return {name, quantity, set};
   }
 
-  inputToCardNames(rawInput) {
+  parseInput(rawInput) {
     const lines = rawInput.split("\n").filter(l => l.trim().length > 0);
-    const [maindeckCardNames, sideboardCardNames] = [[], []];
-    var currentSection = maindeckCardNames;
+    const sections = [[], []]; // two sections - maindeck and sideboard
+    var currentSection = sections[0];
 
     for (var line of lines) {
       if (line.includes('Sideboard')) {
-        currentSection = sideboardCardNames;
+        currentSection = sections[1];
         continue;
       }
 
       currentSection.push(this.parseLine(line));
     }
 
-    return [maindeckCardNames, sideboardCardNames];
+    return sections;
   }
 
   load() {
     const rawInput = document.getElementById(this.props.inputElementId).value;
-    const [maindeckCardNames, sideboardCardNames] = this.inputToCardNames(rawInput);
+    const [maindeckCardEntries, sideboardCardEntries] = this.parseInput(rawInput);
 
     const numCols = this.props.topLevelContainer.state.boardState.numCols;
     const cardLoader = this.props.topLevelContainer.state.cardLoader;
     this.props.topLevelContainer.setState({
-      boardState: new BoardState(cardLoader, maindeckCardNames, numCols, this.props.topLevelContainer),
-      sideboardState: new BoardState(cardLoader, sideboardCardNames, 1, this.props.topLevelContainer)
+      boardState: new BoardState(cardLoader, maindeckCardEntries, numCols, this.props.topLevelContainer),
+      sideboardState: new BoardState(cardLoader, sideboardCardEntries, 1, this.props.topLevelContainer)
     });
   }
 

--- a/src/importExport.js
+++ b/src/importExport.js
@@ -65,8 +65,8 @@ class LoadInputButton extends React.Component {
     const numCols = this.props.topLevelContainer.state.boardState.numCols;
     const cardLoader = this.props.topLevelContainer.state.cardLoader;
     this.props.topLevelContainer.setState({
-      boardState: new BoardState(cardLoader, maindeckCardNames, numCols),
-      sideboardState: new BoardState(cardLoader, sideboardCardNames, 1)
+      boardState: new BoardState(cardLoader, maindeckCardNames, numCols, this.props.topLevelContainer),
+      sideboardState: new BoardState(cardLoader, sideboardCardNames, 1, this.props.topLevelContainer)
     });
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const CARD_STACKING_OFFSET = 25;
 const NUM_COLS = 8; // TODO: make this consistent with css width
 const INITIAL_CARD_NAMES = ['Battle Hymn', 'Reaper King', 'Death or Glory', 'Mindless Automaton',
                             'Wizard Mentor', 'Crow Storm', "Gaea's Touch"];
-const INITIAL_CARD_INFOS = INITIAL_CARD_NAMES.map(name => ({name, quantity: 1, set: ''}));
+const INITIAL_CARD_ENTRIES = INITIAL_CARD_NAMES.map(name => ({name, quantity: 1, set: ''}));
 
 // Card react component - displays a single draggable card. If you hover over the normal card image, 
 // also displays a larger version next to it.
@@ -153,7 +153,7 @@ class TopLevelContainer extends React.Component {
     const cardLoader = new CardLoader();
     this.state = {
       cardLoader: cardLoader,
-      boardState: new BoardState(cardLoader, INITIAL_CARD_INFOS, NUM_COLS, this),
+      boardState: new BoardState(cardLoader, INITIAL_CARD_ENTRIES, NUM_COLS, this),
       sideboardState: new BoardState(cardLoader, [], 1, this),
     };
   }

--- a/src/index.js
+++ b/src/index.js
@@ -162,7 +162,7 @@ class TopLevelContainer extends React.Component {
     board.removeCard(card);
     otherBoard.addCard(card);
     // Hacky way to force everything to re-render; TODO: make board states immutable and directly set the state with new versions
-    this.setState(this.state);
+    this.setState({});
   }
 
   async addLand(landName, count) {

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ const CARD_STACKING_OFFSET = 25;
 const NUM_COLS = 8; // TODO: make this consistent with css width
 const INITIAL_CARD_NAMES = ['Battle Hymn', 'Reaper King', 'Death or Glory', 'Mindless Automaton',
                             'Wizard Mentor', 'Crow Storm', "Gaea's Touch"];
+const INITIAL_CARD_INFOS = INITIAL_CARD_NAMES.map(name => ({name, quantity: 1, set: ''}));
 
 // Card react component - displays a single draggable card. If you hover over the normal card image, 
 // also displays a larger version next to it.
@@ -152,7 +153,7 @@ class TopLevelContainer extends React.Component {
     const cardLoader = new CardLoader();
     this.state = {
       cardLoader: cardLoader,
-      boardState: new BoardState(cardLoader, INITIAL_CARD_NAMES, NUM_COLS),
+      boardState: new BoardState(cardLoader, INITIAL_CARD_INFOS, NUM_COLS),
       sideboardState: new BoardState(cardLoader, [], 1),
     };
   }

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ function Card(props) {
     })
   });
 
-  const imageURL = `https://api.scryfall.com/cards/named?format=image&exact=${encodeURI(props.card.name)}`;
+  const imageURL = props.card.data ? props.card.data.imageURL : ''
 
   const [hoverVisible, setHoverVisible] = useState(false);
   const hoverVisibility = (hoverVisible && !isDragging) ? 'visible' : 'hidden';
@@ -153,8 +153,8 @@ class TopLevelContainer extends React.Component {
     const cardLoader = new CardLoader();
     this.state = {
       cardLoader: cardLoader,
-      boardState: new BoardState(cardLoader, INITIAL_CARD_INFOS, NUM_COLS),
-      sideboardState: new BoardState(cardLoader, [], 1),
+      boardState: new BoardState(cardLoader, INITIAL_CARD_INFOS, NUM_COLS, this),
+      sideboardState: new BoardState(cardLoader, [], 1, this),
     };
   }
   

--- a/src/index.js
+++ b/src/index.js
@@ -165,14 +165,15 @@ class TopLevelContainer extends React.Component {
     this.setState(this.state);
   }
 
-  addLand(landName, count) {
+  async addLand(landName, count) {
     const currentBoard = this.state.boardState;
     const cardLoader = this.state.cardLoader;
-    Array(count).fill(null).forEach(function() {
-      const card = cardLoader.getCardData(landName)
+    for (var _ of Array(count)) {
+      const card = await cardLoader.getCardData(landName)
       currentBoard.addCard(card)
-    });
-    this.setState(this.state);
+    }
+
+    this.setState({});
   }
 
   render() {


### PR DESCRIPTION
The "load cards" input now loads specific printings of cards if the set names are specified in this format:

```
1 Merfolk Looter (M12)
1 Satyr Wayfinder (BNG)
```

Which now produces:
![image](https://user-images.githubusercontent.com/6564873/92321068-bf9f8400-efdb-11ea-8e10-daf00ecf677e.png)

Before this change:
![image](https://user-images.githubusercontent.com/6564873/92321069-c9c18280-efdb-11ea-98a9-4d4c67860fa7.png)

Also added:

- Error handling - set default values for a card if the call to scryfall fails. If some requests succeed and some fail, this allows the cards which succeeded to be sorted.
- Card data cache - don't make repeated requests to scryfall when adding multiple basic lands.