### PR TITLE
Initialize card pool input textarea with initial cards

### DIFF
--- a/src/importExport.js
+++ b/src/importExport.js
@@ -6,7 +6,7 @@ import BoardState from './boardState.js';
 // Card pool input components
 const CardPoolInput = function (props) {
   return (
-    <textarea id={props.id} rows="5" cols="33"></textarea>
+    <textarea id={props.id} rows="5" cols="33">{props.initialText}</textarea>
   );
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -196,7 +196,7 @@ class TopLevelContainer extends React.Component {
       <div>
         <Board boardState={this.state.boardState} moveCardToOtherBoard={moveCardToSideboard} />
         <Board boardState={this.state.sideboardState} moveCardToOtherBoard={moveCardToMainboard} />
-        <CardPoolInput id={CARD_POOL_INPUT_ELEMENT_ID} />
+        <CardPoolInput id={CARD_POOL_INPUT_ELEMENT_ID} initialText={initialCards()} />
         <LoadInputButton inputElementId={CARD_POOL_INPUT_ELEMENT_ID} topLevelContainer={this} />
         <SortByCmcButton topLevelContainer={this} />
         <SortByColorButton topLevelContainer={this} />


### PR DESCRIPTION
Whatever the initial cards are, either the default ones or ones from the `cards` query param, put them into the card pool input text area.

This lets the user easily add additional cards by typing them into the textarea.